### PR TITLE
Pass stdout from codesign into debug and err output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules/
 npm-debug.log
+.idea

--- a/lib/index.js
+++ b/lib/index.js
@@ -94,7 +94,7 @@ function run(cmd, args, opts, fn) {
           output: Buffer.concat(output).toString('utf-8')
         });
         fn(new Error('Command failed!  '
-          + 'Please try again with debugging enabled.'));
+          + 'Please try again with debugging enabled.'), Buffer.concat(output).toString('utf-8'));
         return;
       }
       debug('completed! %j', {

--- a/lib/index.js
+++ b/lib/index.js
@@ -90,7 +90,8 @@ function run(cmd, args, opts, fn) {
           bin: bin,
           args: args,
           opts: opts,
-          code: code
+          code: code,
+          output: Buffer.concat(output).toString('utf-8')
         });
         fn(new Error('Command failed!  '
           + 'Please try again with debugging enabled.'));


### PR DESCRIPTION
Currently when I am running code sign if I get an error (i.e. verification fails using code-sign) it requires manually running the command to see the error. 

By providing some way to view the stdout from the error it will make debugging codesign easier.

I've added the output buffer to the debug call and second param of the callback function provided to run()

If accepted, I will create another PR to pass this information to electron-installer-codesign for easier debugging.
